### PR TITLE
chore/run-linter-when push

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,10 @@ allOpen {
     annotation("javax.persistence.Embeddable")
 }
 
+tasks.check {
+    dependsOn("installKotlinterPrePushHook")
+}
+
 tasks.withType<KotlinCompile>().all {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")


### PR DESCRIPTION
push할 때 linter를 돌릴 수 있도록 
gradle check를 하는 경우, pre-push hook을 설치하도록 합니다.