### PR TITLE
fixed/embedded redis require docker environment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     testImplementation("com.h2database:h2")
     runtimeOnly("mysql:mysql-connector-java:8.0.25")
     testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.3.1")
-    testImplementation("org.testcontainers:testcontainers:1.16.3")
+    testImplementation("com.asarkar.spring:embedded-redis-spring:1.1.1")
 
     implementation("org.apache.httpcomponents.client5:httpclient5:5.1.3")
 

--- a/src/test/kotlin/io/mustelidae/smoothcoatedotter/api/config/FlowTestSupport.kt
+++ b/src/test/kotlin/io/mustelidae/smoothcoatedotter/api/config/FlowTestSupport.kt
@@ -1,5 +1,6 @@
 package io.mustelidae.smoothcoatedotter.api.config
 
+import com.asarkar.spring.test.redis.AutoConfigureEmbeddedRedis
 import io.mustelidae.smoothcoatedotter.SmoothCoatedOtterApplication
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc
 @SpringBootTest(classes = [SmoothCoatedOtterApplication::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(classes = [DefaultEmbeddedMongo::class, DefaultEmbeddedRedis::class])
 @AutoConfigureMockMvc
+@AutoConfigureEmbeddedRedis
 class FlowTestSupport {
 
     @Autowired


### PR DESCRIPTION
테스트를 돌리기 위해 
로컬 환경에 docker가 반드시 설치 되어야하는 이슈가 있어 
embedded redis를 교체